### PR TITLE
fix: undefined owner object from item

### DIFF
--- a/source/index/stargazed.js
+++ b/source/index/stargazed.js
@@ -88,9 +88,9 @@ function generateStargazedList(list) {
       html_url,
       language,
       stargazers_count,
-      owner: {login},
     } = item;
 
+    let login = item.owner ? item.owner.login: item.full_name.replace(`${item.name}/`, ''); 
     language = language || 'Others';
     description = description ? description.trim().htmlEscape() : '';
 


### PR DESCRIPTION
I believe this will resolves #54.

I getting same error as mentioned in issue, the owner object undefined due to some reason. In my case is the repo is deleted by owner but seem Github didn't handle it well, that particular repo still returned part of my starred list.